### PR TITLE
[Fix] 배포 오류 해결을 위한 Dockerfile entrypoint.sh 경로 재수정

### DIFF
--- a/dockerfile
+++ b/dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # 5. FastAPI 앱 및 스크립트 복사
 COPY ./Prompting /app/Prompting
-COPY ./scripts /app/scripts
+COPY ./Prompting/scripts /app/scripts
 
 # 6. entrypoint.sh 복사 및 실행 권한 부여
 COPY ./Prompting/entrypoint.sh /app/entrypoint.sh


### PR DESCRIPTION
## 수정 사항
- #13 에서 상대 경로를 Dockerfile 기준이 아닌 Prompting 디렉터리 기준으로 작성한 실수를 고침.
  - `scripts/`와 `entrypoint.sh` COPY 경로