### PR TITLE
[Fix] 테스트 데이터 삽입 오류 해결을 위한 insert_test_data.py 실행 위치 수정

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,7 +9,7 @@ chmod 400 /app/.env
 
 # 2. 테스트 데이터 삽입 (이미 존재 시 건너뜀)
 echo "📦 Checking test data..."
-python /app/Prompting/scripts/insert_test_data.py
+PYTHONPATH=/app python /app/Prompting/scripts/insert_test_data.py
 
 # 3. FastAPI 서버 실행
 echo "🚀 Starting FastAPI server..."


### PR DESCRIPTION
## 개요
- #15 로 해결되지 않은 오류 다시 디버깅
- `entrypoint.sh`에서 `insert_test_data.py` 실행 시 탐색 경로가 `Prompting/scripts/` 기준으로 설정되어 문제가 생기는 것으로 추정

## 수정 사항
- PYTHONPATH로 `insert_test_data.py `스크립트 실행 시 탐색 경로가 `app/` 기준이 되도록 수정