### PR TITLE
[Feat] 테스트 데이터 삽입 전 기존 테스트 데이터 삭제 기능 추가

### DIFF
--- a/Prompting/scripts/insert_test_data.py
+++ b/Prompting/scripts/insert_test_data.py
@@ -2,8 +2,10 @@ from Prompting.repository.mongo_client import MONGO_URI, ROOM_COLLECTION, CHAT_C
 from pymongo import MongoClient
 from datetime import datetime, timedelta
 import json
+import os
 
-JSON_FILE_PATH = "./Prompting/scripts/data/meeting_log_sample_2.json"  # 회의 채팅 내역 샘플 데이터 파일 경로
+base_dir = os.path.dirname(os.path.abspath(__file__))
+JSON_FILE_PATH = os.path.join(base_dir, "./data/meeting_log_sample_2.json")  # 회의 채팅 내역 샘플 데이터 파일 경로
 BOT_MBTI = "ENFP"
 TEST_ROOM_ID = "TEST_ROOM_ID"
 
@@ -11,7 +13,7 @@ client = MongoClient(MONGO_URI)
 db = client[MONGO_DB_NAME]
 
 def already_inserted():
-    return db[ROOM_COLLECTION].find_one({"meta.version": "v1"}) is not None
+    return db[ROOM_COLLECTION].find_one({"_id": TEST_ROOM_ID}) is not None
 
 def insert_chatroom(title, content, host, participants, mbti=BOT_MBTI):
     chatroom = {

--- a/Prompting/scripts/remove_test_data.py
+++ b/Prompting/scripts/remove_test_data.py
@@ -1,0 +1,23 @@
+from Prompting.repository.mongo_client import MONGO_URI, ROOM_COLLECTION, CHAT_COLLECTION, AGENDA_COLLECTION, USER_COLLECTION, MONGO_DB_NAME
+from pymongo import MongoClient
+
+
+client = MongoClient(MONGO_URI)
+db = client[MONGO_DB_NAME]
+
+# 테스트 기준값(버전이나 room_id)
+# TEST_ROOM_ID = "TEST_ROOM_ID"
+TEST_VERSION = "v1"
+
+def remove_all():
+    print("🧹 Removing test data...")
+
+    db[ROOM_COLLECTION].delete_many({"meta.version": TEST_VERSION})
+    db[AGENDA_COLLECTION].delete_many({"meta.version": TEST_VERSION})
+    db[CHAT_COLLECTION].delete_many({"meta.version": TEST_VERSION})
+    db[USER_COLLECTION].delete_many({"meta.version": TEST_VERSION})
+
+    print("✅ Done removing test data.")
+
+if __name__ == "__main__":
+    remove_all()

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -9,6 +9,7 @@ chmod 400 /app/.env
 
 # 2. 테스트 데이터 삽입 (이미 존재 시 건너뜀)
 echo "📦 Checking test data..."
+PYTHONPATH=/app python /app/Prompting/scripts/remove_test_data.py  # import 경로 때문에 PYTHONPATH 지정 필요
 PYTHONPATH=/app python /app/Prompting/scripts/insert_test_data.py
 
 # 3. FastAPI 서버 실행


### PR DESCRIPTION
## 개요
**배포 시 테스트 환경 초기화**를 위해 entrypoint에서 테스트 데이터 삽입 전, 
**기존 테스트 데이터를 삭제**하는 기능 구현 버전(#18 )을 `main` 브랜치에 반영
해당 기능 추가에 대한 자세한 사유는 위 PR을 확인

## 주요 변경 사항(#18 과 동일)
- Prompting/scripts/`remove_test_data.py` 추가
  - `meta.version` == `"v1"` 기준으로 테스트 데이터 전체 제거
- `entrypoint.sh` 수정
  - `insert_test_data.py` 실행 전에 `remove_test_data.py` 먼저 실행

---

🔗 관련 브랜치:
- `feat/remove-testdata-before-insert`
