### PR TITLE
Feat: GitHub Actions를 활용한 Discord 알림 기능 추가

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -1,0 +1,45 @@
+name: Discord Notify
+
+on:
+  push:
+    branches:
+      - main
+
+  pull_request:
+    types: [closed]
+    branches:
+      - main  # main으로 머지된 PR만
+
+  issues:
+    types: [opened, closed]
+
+jobs:
+  notify:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Send message to Discord
+        uses: Ilshidur/action-discord@master
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          message: |
+            📣 **[${{ github.repository }}] 주요 업데이트**
+            
+            {% if github.event_name == 'push' %}
+            🔄 **Push to `main`**
+            - Author: `${{ github.actor }}`
+            - Commit: [{{ github.event.head_commit.message }}]({{ github.event.head_commit.url }})
+            {% endif %}
+
+            {% if github.event_name == 'pull_request' %}
+            ✅ **Pull Request Merged**
+            - Author: `${{ github.actor }}`
+            - Title: [{{ github.event.pull_request.title }}]({{ github.event.pull_request.html_url }})
+            - #${{ github.event.pull_request.number }} merged into `main`
+            {% endif %}
+
+            {% if github.event_name == 'issues' %}
+            🚨 **Issue ${{ github.event.action }}**
+            - Author: `${{ github.actor }}`
+            - Title: [{{ github.event.issue.title }}]({{ github.event.issue.html_url }})
+            - #${{ github.event.issue.number }}
+            {% endif %}

--- a/.github/workflows/workflow-run-discord.yml
+++ b/.github/workflows/workflow-run-discord.yml
@@ -1,0 +1,29 @@
+name: Notify Discord on main.yml result
+
+on:
+  workflow_run:
+    workflows: ["main"]
+    types:
+      - completed
+
+jobs:
+  discord-notify:
+    # 성공 or 실패일 때만 실행
+    if: |
+      github.event.workflow_run.conclusion == 'success' ||
+      github.event.workflow_run.conclusion == 'failure'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Notify Discord
+        uses: Ilshidur/action-discord@v1.0.0
+        with:
+          webhook: ${{ secrets.DISCORD_WEBHOOK }}
+          message: |
+            📣 **[${{ github.repository }}] 배포 결과**
+
+            ⚙️ Workflow **`${{ github.event.workflow_run.name }}`** Completed
+            - Result: {% if github.event.workflow_run.conclusion == 'success' %}Success ✅{% endif %}
+           {% if github.event.workflow_run.conclusion == 'failure' %}Failure ❌{% endif %}
+            - Branch: `${{ github.event.workflow_run.head_branch }}`
+            - Author: `${{ github.event.workflow_run.head_commit.author.name }}`
+            - 🔗 [View run](${{ github.event.workflow_run.html_url }})


### PR DESCRIPTION
## 개요
- 이 레포지토리 관련 **주요 활동에 대한 Discord 채널 알림** 기능 추가
- 중요한 활동에 대한 알림만을 보내기 위해 **GitHub Actions**를 활용해 세부 조건 커스텀

## 알림 설정 세부 조건
- `.github/workflows/discord.yml`: 
  - `main` 브랜치로의 **push** 이벤트
  - `dev → main` **PR Merge** (closed 상태 + base가 main인 경우)
  - 모든 **Issue open/close** 이벤트

- `.github/workflows/workflow-run-discord.yml`:
  - workflow_run 이벤트 기반으로 **`main.yml` 실행 완료 시점** 감지
  - **`success`, `failure` 결론**일 때만 알림 전송 (cancelled, skipped 등은 무시)

## 참고
- Ilshidur/action-discord 액션 사용
- Discord Webhook은 GitHub Secrets (`DISCORD_WEBHOOK`)를 통해 관리
- 알림 메시지 포맷에 대한 피드백 환영

## 메시지 예시
> 📣 [New-Duksung-Electronics/mindsync-ai] 주요 업데이트
> 🔄 **Push to `main`**
> - 👤 Author: `moon0900`
> - Commit: _feat: main.yml(자동 배포) 결과 Discord 알림 기능 추가(link)_

> 📣 [New-Duksung-Electronics/mindsync-ai] 배포 결과 알림  
> ⚙️ Workflow `main` Completed
> - Result: Success ✅  
> - Branch: `main`  
> - Author: `moon0900`
> - 🔗 _View run(link)_