### PR TITLE
[CI/CD] Discord 알림 오류 및 배포 시 세부 작업 병렬 실행 이슈 해결 (#26~30)

### DIFF
--- a/.github/workflows/discord.yml
+++ b/.github/workflows/discord.yml
@@ -23,24 +23,35 @@ jobs:
         uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
         with:
           args: |
-            📣 **[{{ EVENT_PAYLOAD.repository.full_name }}] 주요 업데이트**
+            <% if (EVENT_PAYLOAD.head_commit) { %>
+            ## 🔄 **Push to `main`**
+            A [new commit]({{ EVENT_PAYLOAD.head_commit.url }}) has been pushed to `main` by `{{ EVENT_PAYLOAD.sender.login }}` 👩‍💻 
             
-            {% if EVENT_PAYLOAD.head_commit %}
-            🔄 **Push to `main`**
-            - Author: `{{ EVENT_PAYLOAD.sender.login }}`
-            - Commit: [{{ EVENT_PAYLOAD.head_commit.message }}]({{ EVENT_PAYLOAD.head_commit.url }})
-            {% endif %}
+            **Commit Message**: 
+            ```
+            {{ EVENT_PAYLOAD.head_commit.message }}
+            ```
+            <% } %>
+            <% if (EVENT_PAYLOAD.pull_request) { %>
+            ## ✅ **Pull Request Merged**
+            [`#{{ EVENT_PAYLOAD.pull_request.number }}`]({{ EVENT_PAYLOAD.pull_request.html_url }}) merged into `main` by `{{ EVENT_PAYLOAD.sender.login }}` 👩‍💻 
+            
+            **PR Title**: `{{ EVENT_PAYLOAD.pull_request.title }}`
+            <% if (EVENT_PAYLOAD.pull_request.body) { %>**PR Description**: 
+            ```
+            {{ EVENT_PAYLOAD.pull_request.body }}
+            ```
+            <% } %>
+            <% } %>
+            <% if (EVENT_PAYLOAD.issue) { %>
+            ## 🚨 **Issue {{ EVENT_PAYLOAD.action }}**
+            [`#{{ EVENT_PAYLOAD.issue.number }}`]({{ EVENT_PAYLOAD.issue.html_url }}) {{ EVENT_PAYLOAD.action }} by `{{ EVENT_PAYLOAD.sender.login }}` 👩‍💻 
+            
+            **Issue Title**: `{{ EVENT_PAYLOAD.issue.title }}`
+            <% if (EVENT_PAYLOAD.issue.body) { %>**Issue Description**: 
+            ```
+            {{ EVENT_PAYLOAD.issue.body }}
+            ```
+            <% } %>
+            <% } %>
 
-            {% if EVENT_PAYLOAD.pull_request %}
-            ✅ **Pull Request Merged**
-            - Author: `{{ EVENT_PAYLOAD.sender.login }}`
-            - Title: [{{ EVENT_PAYLOAD.pull_request.title }}]({{ EVENT_PAYLOAD.pull_request.html_url }})
-            - #{{ EVENT_PAYLOAD.pull_request.number }} merged into `main`
-            {% endif %}
-
-            {% if EVENT_PAYLOAD.issue %}
-            🚨 **Issue {{ EVENT_PAYLOAD.action }}**
-            - Author: `{{ EVENT_PAYLOAD.sender.login }}`
-            - Title: [{{ EVENT_PAYLOAD.issue.title }}]({{ EVENT_PAYLOAD.issue.html_url }})
-            - #{{ EVENT_PAYLOAD.issue.number }}
-            {% endif %}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,6 +38,7 @@ jobs:
       
   deploy-to-ubuntu-server:
     name: Deploy to EC2
+    needs: build-and-push
     runs-on: ubuntu-latest
   
     steps:

--- a/.github/workflows/workflow-run-discord.yml
+++ b/.github/workflows/workflow-run-discord.yml
@@ -2,7 +2,7 @@ name: Notify Discord on main.yml result
 
 on:
   workflow_run:
-    workflows: ["main"]
+    workflows: ["Deploy FastAPI to EC2"]
     types:
       - completed
 
@@ -20,12 +20,14 @@ jobs:
         uses: Ilshidur/action-discord@0c4b27844ba47cb1c7bee539c8eead5284ce9fa9
         with:
           args: |
-            📣 **[{{ EVENT_PAYLOAD.repository.full_name }}] 배포 결과**
-
-            ⚙️ Workflow **`{{ EVENT_PAYLOAD.workflow_run.name }}`** Completed
-            - Result: 
-              {% if EVENT_PAYLOAD.workflow_run.conclusion == 'success' %}Success ✅{% endif %}
-              {% if EVENT_PAYLOAD.workflow_run.conclusion == 'failure' %}Failure ❌{% endif %}
-            - Branch: `{{ EVENT_PAYLOAD.workflow_run.head_branch }}`
-            - Author: `{{ EVENT_PAYLOAD.workflow_run.head_commit.author.name }}`
-            - 🔗 [View run]({{ EVENT_PAYLOAD.workflow_run.html_url }})
+            <% if (EVENT_PAYLOAD.workflow_run.conclusion == 'success') { %>
+            ## ✅ Workflow **`{{ EVENT_PAYLOAD.workflow_run.name }}`** Succeeded
+            <% } else if (EVENT_PAYLOAD.workflow_run.conclusion == 'failure') { %>
+            ## ❌ Workflow **`{{ EVENT_PAYLOAD.workflow_run.name }}`** Failed
+            <% } %>
+            Executed on `{{ EVENT_PAYLOAD.workflow_run.head_branch }}` by `{{ EVENT_PAYLOAD.workflow_run.head_commit.author.name }}` 👩‍💻 (view [Run Details]({{ EVENT_PAYLOAD.workflow_run.html_url }}))
+            
+            **Head Commit**:
+            ```
+            {{ EVENT_PAYLOAD.workflow_run.head_commit.message }}
+            ```


### PR DESCRIPTION
## 개요
- #26 ~ #30 까지 이어진 디스코드 알림 오류를 해결하여, **레포지토리의 주요 변경사항에 대한 알림**과 **자동 배포 종료 시 성공/실패 여부에 대한 알림** 기능 구현을 완료
- 서버 자동 배포 워크플로우(`main.yml`)에서 세부 작업 간 의존성을 추가해 **후속 작업을 수동으로 re-run 해주던 문제 해결**

## 주요 변경 사항

**자동 배포 시 세부 작업의 순서 보장 (Job 간 의존성 설정)**:
  - `deploy-to-ubuntu-server` job에 `needs: build-and-push`를 명시하여, Docker 이미지 빌드가 완료된 후에만 배포가 진행되도록 수정
  - 이전까지 발생하던 조기 실행 및 manual re-run 문제 해결

**레포지토리 주요 변경사항에 대한 Discord 알림 구현**:
  - `.github/workflows/discord.yml`에서 구현
  - 다음 조건에 대한 알림 등록: 
    - `main` 브랜치로의 **push** 이벤트
    - `dev` → `main` **PR Merge** (closed 상태 + base가 main인 경우)
    - 모든 **Issue open/close** 이벤트
   
**자동 배포 작업 결과에 대한 Discord 알림 구현**:
  - `.github/workflows/workflow-run-discord.yml`에서 구현.
  - workflow_run 이벤트 기반으로 `main.yml` 실행 완료 시점 감지
  - success, failure 결론일 때만 알림 전송 (cancelled, skipped 등은 무시)


## 테스트/검토 사항
#30 에서 언급한대로 별도 레포지토리에서 정상 작동 검증 완료
- [x] Discord 알림 정상 동작 (각 이벤트 유형별 메시지 포맷 검증 완료)
- [x] 커밋 메시지/본문 줄바꿈 시에도 메시지 형식 안정적으로 출력됨