### PR TITLE
[Feat] AI 안건 생성 시 마지막 요소로 예비 안건 자동 추가

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,12 +92,11 @@ jobs:
               -v $LOG_DIR/app.log:/app/logs \
               ${{ env.DOCKER_IMAGE_NAME }}:latest
 
-            # 배포 후 컨테이너 로그 출력
+            # 배포 후 컨테이너가 잘 돌아가는지 확인
             sleep 3  # 컨테이너가 완전히 실행될 때까지 대기
-            echo "Start printing container logs..."
             CONTAINER_ID=$(sudo docker ps -q --filter "name=mindsync-ai-container")
             if [ ! -z "$CONTAINER_ID" ]; then
-              echo "${{ secrets.SUDO_PASSWORD }}" | sudo -S docker logs $CONTAINER_ID
+              echo "CONTAINER is running Successfully"
             else
               echo "NO CONTAINER is running"
             fi

--- a/Prompting/repository/agenda_repository.py
+++ b/Prompting/repository/agenda_repository.py
@@ -17,6 +17,10 @@ class AgendaRepository:
         Returns:
             MongoDB에 저장된 안건 문서의 `_id` 필드 (문자열 형태)
         """
+        # 마지막 요소로 추가 논의를 위한 예비 안건 추가
+        last_agenda_id = str(len(agenda_dict) + 1)
+        agenda_dict[last_agenda_id] = "예비 안건 (회의 중 추가 논의 시)"
+
         result = await self.collection.update_one(
             {"_id": room_id},  # 검색 기준
             {"$set": {"roomId": room_id, "agendas": agenda_dict}},  # 갱신 필드


### PR DESCRIPTION
## 개요

회의 시작 전에 논의할 안건 리스트를 확정하는 현재 시스템 구조에서는, 회의 중 새로운 안건이 필요할 경우 유연한 대응이 어려웠음.  
이에 따라 5월 7일 팀 회의에서 논의된 바와 같이, **AI를 통한 안건 자동 생성 시 '예비 안건'을 마지막에 자동 추가**하는 기능을 구현하였음.

또한, 레포지토리를 공개함에 따라 **GitHub Actions에서 출력되던 Docker 로그**가 민감 정보 노출 우려를 야기할 수 있어 이를 대처하였음.


## 주요 변경 사항

- **[기능]** AgendaRepository: 안건 생성 시 `"예비 안건 (회의 중 추가 논의 시)"` 자동 추가
- **[보안]** .github/workflows: FastAPI 앱 배포 시 Docker 로그 출력 제거 (공개 레포 대응)


## 브랜치
`feat/agenda-reserve-and-logfix`

## 후속 작업 예정 (TODO)
- [ ] **회의 중 실제로는 생략된 안건에 대한 대응 논의 이슈 등록**  
  ↳ 회의 중 생략된 안건이 요약 또는 AI 채팅(MBTI 봇) 생성 시 어떻게 처리되어야 할지 기준 필요
- [ ] **기존 GitHub Actions 로그 내역 정리**  
  ↳ 공개 레포 전환 이전의 Docker 로그 출력 커밋/이력에 민감 정보가 포함되어 있을 수 있음
