### PR TITLE
[Feat] 회의 안건 status(논의 상태) 도입 및 관련 로직 개선

### DIFF
--- a/Prompting/README.md
+++ b/Prompting/README.md
@@ -42,6 +42,8 @@ Prompting/
 ├── schemas/             # 요청/응답 데이터 구조
 ├── exceptions/          # 공통 에러 및 핸들러
 ├── common/              # 편의를 위한 공통 모듈
+├── scripts/            # 테스트 데이터 삽입 및 유틸리티 스크립트
+├── docs/               # Prompting 모듈 관련 문서 모음
 └── README.md            # (현재 문서)
 ```
 
@@ -49,15 +51,15 @@ Prompting/
 
 ## ⚙️ 주요 클래스
 
-| 분류                  | 클래스                      | 설명                     |
-|---------------------|-----------------------------|------------------------|
-| `services/`         | `AgendaGenerator`           | 주제 기반 회의 안건 생성         |
-|                     | `MeetingSummarizer`         | 채팅 로그 기반 회의 요약 생성      |
-|                     | `MbtiChatGenerator`         | MBTI 성격 특징 기반 챗봇 발화 생성 |
-| `context_builders/` | `MeetingHistoryBuilder`     | 채팅 기록 → 프롬프트용 문자열 가공   |
-|                     | `MbtiTraitBuilder`          | MBTI 성향 요약 텍스트 구성      |
-| `repository/`       | `ChatRepository`, ...       | MongoDB 데이터 접근 객체      |
-| `usecases/`         | `load_summary_context`, ... | 데이터 흐름과 도메인 객체 조합 로직   |
+| 분류                  | 클래스                     | 설명                     |
+|---------------------|-------------------------|------------------------|
+| `services/`         | `AgendaGenerator`       | 주제 기반 회의 안건 생성         |
+|                     | `MeetingSummarizer`     | 채팅 로그 기반 회의 요약 생성      |
+|                     | `MbtiChatGenerator`     | MBTI 성격 특징 기반 챗봇 발화 생성 |
+| `context_builders/` | `MeetingHistoryBuilder` | 채팅 기록 → 프롬프트용 문자열 가공   |
+|                     | `MbtiTraitBuilder`      | MBTI 성향 요약 텍스트 구성      |
+| `repository/`       | `ChatRepository`, ...   | MongoDB 데이터 접근 객체      |
+| `usecases/`         | `MeetingContext`, ...   | 회의의 맥락 정보를 담는 컨텍스트 객체  |
 
 <br/>
 

--- a/Prompting/common/__init__.py
+++ b/Prompting/common/__init__.py
@@ -1,0 +1,1 @@
+from .enums import AgendaStatus

--- a/Prompting/common/enums.py
+++ b/Prompting/common/enums.py
@@ -1,0 +1,6 @@
+from enum import Enum
+
+class AgendaStatus(str, Enum):
+    PENDING = "pending",
+    SKIPPED = "skipped",
+    COMPLETE = "complete"

--- a/Prompting/docs/api_spec.md
+++ b/Prompting/docs/api_spec.md
@@ -52,7 +52,8 @@
 ### ✅ 요청 Body
 ```
 {
-  "roomId": "xxxxxxxxxxxxxxxxxxx"
+  "roomId": "xxxxxxxxxxxxxxxxxxx",
+  "is_last_agenda_skipped" : true   # 마지막 안건의 논의 생략 여부
 }
 ```
 
@@ -68,6 +69,11 @@
       "content": "주요 발언: ...\n결론: ..."
     },
     ...
+    {
+      "agendaId": "5",
+      "topic": "예비 안건 (회의 중 추가 논의 시)",
+      "content": null    # 논의가 생략된 안건의 요약은 null 처리
+    }
   ]
 }
 ```
@@ -82,7 +88,8 @@
 ```
 {
   "roomId": "string",
-  "agendaId": "2"
+  "agendaId": "2",
+  "is_previous_skipped" : false   # 직전 안건의 논의 생략 여부
 }
 ```
 ### 🔁 응답 예시

--- a/Prompting/repository/agenda_repository.py
+++ b/Prompting/repository/agenda_repository.py
@@ -1,12 +1,15 @@
 from .mongo_client import db, AGENDA_COLLECTION
 from Prompting.exceptions import MongoAccessError, catch_and_raise
+from Prompting.common import AgendaStatus
+from pymongo import ReturnDocument
+
 
 class AgendaRepository:
     def __init__(self):
         self.collection = db[AGENDA_COLLECTION]
 
     @catch_and_raise("MongoDB 안건 저장", MongoAccessError)
-    async def save_agenda(self, room_id: str, agenda_dict: dict) -> str:
+    async def save_agenda(self, room_id: str, agenda_dict: dict) -> dict:
         """
         안건 데이터를 MongoDB agenda 콜렉션에 저장
 
@@ -21,20 +24,50 @@ class AgendaRepository:
         last_agenda_id = str(len(agenda_dict) + 1)
         agenda_dict[last_agenda_id] = "예비 안건 (회의 중 추가 논의 시)"
 
+        agenda_data = {}  # DB 저장용 (안건명과 논의 상태를 함께 저장)
+        for aid in agenda_dict:
+            title = agenda_dict[aid]
+            agenda_data[aid] = {
+                "title": title,
+                "status": AgendaStatus.PENDING.value
+            }
+
         result = await self.collection.update_one(
             {"_id": room_id},  # 검색 기준
-            {"$set": {"roomId": room_id, "agendas": agenda_dict}},  # 갱신 필드
+            {"$set": {"roomId": room_id, "agendas": agenda_data}},  # 갱신 필드
             upsert=True  # 없으면 새로 insert
         )
 
-        if result.modified_count == 0:
-            if result.upserted_id is not None:
-                print(f"새로 insert된 문서 ID: {result.upserted_id}")
-            else:
-                raise MongoAccessError("회의 안건 저장 실패")
+        if result.modified_count == 0 and result.upserted_id is None:
+            raise MongoAccessError("회의 안건 저장 실패")
+
+        return agenda_dict  # 반환은 안건명만 포함하는 딕셔너리
 
 
     @catch_and_raise("MongoDB 안건 조회", MongoAccessError)
     async def get_agenda_by_room(self, room_id: str) -> dict:
         """채팅방 ID를 기반으로 해당 방의 안건 데이터를 검색"""
         return await self.collection.find_one({"roomId": room_id})
+
+
+    @catch_and_raise("MongoDB 안건 상태 업데이트", MongoAccessError)
+    async def update_status(self, room_id: str, agenda_id: str, is_skipped: bool) -> dict:
+        """
+        안건 데이터에서 특정 안건의 논의 상태를 완료 또는 생략 상태로 업데이트
+
+        Args:
+            room_id: 채팅방 ObjectId
+            agenda_id: 상태를 수정할 안건 ID
+            is_skipped: 안건의 생략 여부. 생략이 아니면 완료로 처리
+        """
+        status = AgendaStatus.SKIPPED if is_skipped else AgendaStatus.COMPLETE
+        updated_agendas = await self.collection.find_one_and_update(
+            {"_id": room_id},
+            {"$set": {f"agendas.{agenda_id}.status": status.value}},
+            projection={"agendas": 1, "_id": 0},
+            return_document=ReturnDocument.AFTER  # 업데이트 후의 값을 반환
+        )
+        if updated_agendas is None:
+            raise MongoAccessError("안건 상태 업데이트 실패")
+
+        return updated_agendas["agendas"]

--- a/Prompting/repository/chat_repository.py
+++ b/Prompting/repository/chat_repository.py
@@ -12,28 +12,23 @@ class ChatRepository:
         cursor = self.collection.find({"roomId": room_id}).sort("timestamp", 1)
         return await cursor.to_list(length=1000)
 
-    @catch_and_raise("MongoDB 직전 안건 채팅 조회", MongoAccessError)
-    async def get_chat_logs_of_previous_agenda(self, room_id: str, current_agenda_id: str) -> list[dict]:
+    @catch_and_raise("MongoDB 지정 안건 채팅 조회", MongoAccessError)
+    async def get_chat_logs_by_agenda_id(self, room_id: str, agenda_id: str) -> list[dict]:
         """
-        현재 안건 ID 기준, 직전 안건의 채팅 기록을 시간 순으로 조회
+        특정 안건에 대한 채팅 기록을 시간 순으로 조회
 
         Args:
             room_id: 채팅방 ID
-            current_agenda_id: 현재 안건 ID
+            agenda_id: 채팅을 조회하려는 안건 ID
 
         Returns:
-            직전 안건에 해당하는 채팅 기록 리스트
+            특정 안건에 대한 채팅 기록 리스트
         """
 
-        try:  # 현재 agenda_id를 int로 변환 (str로 들어와도 대비)
-            current_agenda_num = int(current_agenda_id)
-        except ValueError:
-            raise ValueError("agenda_id는 숫자 형태의 문자열 또는 정수여야 합니다.")
-
-        # 해당 채팅방에서 current_agenda_id의 직전 안건에 대한 모든 chat을 시간 순으로 정렬해 불러오기
+        # 해당 채팅방에서 agenda_id 안건에 대한 모든 chat을 시간 순으로 정렬해 불러오기
         cursor = self.collection.find({
             "roomId": room_id,
-            "agenda_id": str(current_agenda_num - 1)  # MongoDB 저장이 str이라면
+            "agenda_id": agenda_id
         }).sort("timestamp", 1)
 
         return await cursor.to_list(length=1000)

--- a/Prompting/schemas/__init__.py
+++ b/Prompting/schemas/__init__.py
@@ -1,5 +1,5 @@
 from .agenda_request import AgendaRequest
 from .chat_request import ChatRequest
 from .chat_response import ChatResponse
-from .room_id_request import RoomIdRequest
+from .summary_request import SummaryRequest
 from .response import Response

--- a/Prompting/schemas/chat_request.py
+++ b/Prompting/schemas/chat_request.py
@@ -3,3 +3,4 @@ from pydantic import BaseModel
 class ChatRequest(BaseModel):
     roomId: str
     agendaId: str
+    is_previous_skipped: bool = False

--- a/Prompting/schemas/room_id_request.py
+++ b/Prompting/schemas/room_id_request.py
@@ -1,4 +1,0 @@
-from pydantic import BaseModel
-
-class RoomIdRequest(BaseModel):
-    roomId: str

--- a/Prompting/schemas/summary_request.py
+++ b/Prompting/schemas/summary_request.py
@@ -1,0 +1,5 @@
+from pydantic import BaseModel
+
+class SummaryRequest(BaseModel):
+    roomId: str
+    is_last_agenda_skipped: bool = False

--- a/Prompting/scripts/insert_test_data.py
+++ b/Prompting/scripts/insert_test_data.py
@@ -1,4 +1,5 @@
 from Prompting.repository.mongo_client import MONGO_URI, ROOM_COLLECTION, CHAT_COLLECTION, AGENDA_COLLECTION, USER_COLLECTION, MONGO_DB_NAME
+from Prompting.common.enums import AgendaStatus
 from pymongo import MongoClient
 from datetime import datetime, timedelta
 import json
@@ -51,6 +52,14 @@ def insert_user(email, name, mbti="ISTJ", password="1234qwer!"):
     db[USER_COLLECTION].insert_one(chat)
 
 def insert_agenda(roomId, agendas_dict):
+    last_agenda_id = str(len(agendas_dict) + 1)
+    agendas_dict[last_agenda_id] = "예비 안건 (회의 중 추가 논의 시)"
+    for aid in agendas_dict:
+        title = agendas_dict[aid]
+        agendas_dict[aid] = {
+            "title": title,
+            "status": AgendaStatus.PENDING.value
+        }
     agenda = {
         "_id": roomId,
         "roomId": roomId,

--- a/Prompting/services/context_builders/meeting_history_builder.py
+++ b/Prompting/services/context_builders/meeting_history_builder.py
@@ -16,7 +16,7 @@ class MeetingHistoryBuilder:
          - 토큰 수 제한에 맞춰 텍스트를 분할
         """
         self.topic: str = context.topic  # 회의 주제
-        self.agendas: dict[str, str] = context.agendas  # 회의 안건들(번호-주제 쌍)
+        self.agendas: dict[str, str] = { aid: context.agendas[aid]["title"] for aid in context.agendas }  # 회의 안건들(번호-주제 쌍)
         self.host: str = context.host  # 회의 개최자(이메일)
         self.participants: list[UserInfo] = context.participants  # 회의 참여자 리스트
         self.chats: list[ChatLog] = context.chats  # 채팅 기록 리스트

--- a/Prompting/services/mbti_chat_generator.py
+++ b/Prompting/services/mbti_chat_generator.py
@@ -97,8 +97,8 @@ class MbtiChatGenerator:
             mbti_info=mbti_info
         )
 
-        # 회의의 첫 안건이 아니면, 직전 안건 대화 context를 함께 전달
-        if step != min(history_builder.agendas.keys()):
+        # 유효한 직전 안건 대화 context가 존재할 시 함께 전달
+        if history_builder.chats:
             chunks = history_builder.build_prompt_chunks()
             if len(chunks) > 1:
                 raise PromptBuildError("의도치 않은 프롬프트 분할 발생")  # context 뭉치가 분할 처리되었으면 에러 발생시키기

--- a/Prompting/usecases/__init__.py
+++ b/Prompting/usecases/__init__.py
@@ -1,2 +1,2 @@
-from .summarize_usecase import load_summary_context
-from .mbti_chat_usecase import load_chat_context
+from .summarize_usecase import load_summary_context_and_update_agenda_status
+from .mbti_chat_usecase import load_chat_context_and_update_agenda_status

--- a/README.md
+++ b/README.md
@@ -38,20 +38,22 @@ Google Gemini API를 활용해 다음과 같은 편의 기능을 제공합니다
 ```bash
 .
 ├── Dataset/            # (일시 중단) 전용 모델 학습을 위한 데이터셋 수집/전처리 폴더
-├── Prompting/              # AI 기반 회의 지원 백엔드 모듈
+├── Prompting/          # AI 기반 회의 지원 백엔드 모듈
+│   ├── common/             # 공통 유틸 함수 및 enum 클래스 정의
+│   ├── docs/               # Prompting 기반 백엔드 구조 설명, API 명세 등 문서
+│   ├── exceptions/         # 공통 예외 클래스 및 핸들러 정의
 │   ├── repository/         # MongoDB 연동
+│   ├── schemas/            # 요청 및 응답 데이터 구조 정의
+│   ├── scripts/            # 테스트 데이터 삽입 및 유틸리티 스크립트
 │   ├── services/           # Gemini 기반 기능 서비스 (agenda, summary, mbti_chat)
 │   ├── usecases/           # 도메인 중심 데이터 구성 및 흐름 처리
-│   ├── exceptions/         # 공통 예외 클래스 및 핸들러 정의
-│   ├── schemas/            # 요청 및 응답 데이터 구조 정의
 │   ├── di.py               # 의존성 주입 모듈
 │   ├── main.py             # FastAPI 진입점
 │   └── ...
-├── docs/                   # (선택) 구조 설명, API 명세 등 문서화
 ├── requirements.txt
 ├── .env.template
 ├── dockerfile
-└── README.md               # 루트 설명 파일
+└── README.md           # 루트 설명 파일
 ```
 
 <br/>


### PR DESCRIPTION
## 개요
#34 에서 정리한 안건 `status` 도입 및 개선 작업 내역을 배포용 `main` 브랜치에 통합하고자 함.

회의 안건의 논의 상태를 반영하여,
- 생략된 안건을 구분하고
- MBTI 봇 채팅 및 요약 생성 시 적절한 맥락을 참조하도록 전체 회의 흐름 처리 로직을 개선함.

## 주요 변경 사항
- 안건의 논의 상태를 나타내는 `AgendaStatus`(enum) 정의 및 활용
- **`AgendaRepository`:** 안건 status 수정 기능 추가, 안건 저장 시 status 기본값(`pending`) 자동 지정
- **`ChatRepository`:** MBTI 봇 채팅 생성 시 맥락으로 참조할 채팅 내역 로드 방식 수정
- MBTI 봇 채팅 및 요약 생성 요청 **스키마 변경** & **해당 요청 처리 시 안건 status 업데이트 로직 추가**
- **채팅 생성 서비스 로직**: 직전 안건이 생략된 경우 맥락 참조 생략 처리
- **요약 생성 서비스 로직**: 생략된 안건의 요약 content를 `null` 처리
- **`usecase` 및 FastAPI 엔트리포인트**: 안건 상태 업데이트 흐름 통합
- 테스트용 더미 데이터 스크립트에 status 필드 반영

## 관련 이슈
#33 [Discussion] 논의되지 않은 안건(예비 안건 포함) 대응 방식 논의 필요
#34 [Enhancement] 안건 status 관리 및 AI 기능 반영 작업