### PR TITLE
fix: agendaId 필드를 str로 통일 (roomId 구조 확정 전 선작업)

### DIFF
--- a/Prompting/services/meeting_summarizer.py
+++ b/Prompting/services/meeting_summarizer.py
@@ -142,7 +142,7 @@ class MeetingSummarizer:
                 summary_content = key_statements_text + conclusion_text
 
             agenda_summary = {
-                "agendaId": step,
+                "agendaId": str(step),
                 "topic": sub_topic,
                 "content": summary_content
             }


### PR DESCRIPTION
## 개요
- `summary` 필드 내 `agendaId`가 일부 케이스에서 int로 저장되는 문제를 확인하여, 문자열(str)로 통일하는 수정.
- 본 PR은 향후 진행될 수 있는 `roomId` 관련 구조 개편 작업과 병합하여 처리하기 위한 **선작업 브랜치**.
- **현재 상태에서는 dev에 머지하지 않고, 관련 구조 확정 후 함께 머지될 예정.**

## 주요 변경사항
summary 생성 시 `agendaId`를 `str()`로 형변환하여 저장되도록 수정

## 테스트/검토사항
- [x] summary 저장 결과의 `agendaId`가 문자열로 일관되게 저장되는지 확인 완료

## 관련 이슈
-  `roomId` vs `_id` 중복 필드 처리 기준 결정 이슈와 연관 (#37 )
