### PR TITLE
[Fix] chatroom 컬렉션에 roomId 필드 추가

### DIFF
--- a/Prompting/common/resonse_util.py
+++ b/Prompting/common/resonse_util.py
@@ -1,13 +1,14 @@
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from typing import Optional, Any
 
 
 def success_response(data: Optional[Any] = None, message: str = "요청이 성공했습니다."):
     return JSONResponse(
         status_code=200,
-        content={
+        content=jsonable_encoder({
             "status": "SUCCESS",
             "message": message,
             "data": data
-        }
+        })
     )

--- a/Prompting/repository/room_repository.py
+++ b/Prompting/repository/room_repository.py
@@ -9,7 +9,7 @@ class RoomRepository:
     @catch_and_raise("MongoDB 채팅방 정보 조회", MongoAccessError)
     async def get_room_info(self, room_id: str) -> dict:
         """채팅방 ID로 해당 방의 정보를 조회"""
-        doc = await self.collection.find_one({"_id": room_id})
+        doc = await self.collection.find_one({"roomId": room_id})
         return doc
 
     @catch_and_raise("MongoDB 회의 요약 저장", MongoAccessError)
@@ -22,7 +22,7 @@ class RoomRepository:
             summary: 저장할 요약 데이터
         """
         result = await self.collection.update_one(
-            {"_id": room_id},
+            {"roomId": room_id},
             {"$set": {"summary": summary}}
         )
         if result.modified_count == 0:

--- a/Prompting/scripts/insert_test_data.py
+++ b/Prompting/scripts/insert_test_data.py
@@ -19,6 +19,7 @@ def already_inserted():
 def insert_chatroom(title, content, host, participants, mbti=BOT_MBTI):
     chatroom = {
         "_id": TEST_ROOM_ID,
+        "roomId": TEST_ROOM_ID,
         "host_email": host,
         "title": title,
         "content": content,

--- a/Prompting/services/meeting_summarizer.py
+++ b/Prompting/services/meeting_summarizer.py
@@ -142,7 +142,7 @@ class MeetingSummarizer:
                 summary_content = key_statements_text + conclusion_text
 
             agenda_summary = {
-                "agendaId": step,
+                "agendaId": str(step),
                 "topic": sub_topic,
                 "content": summary_content
             }


### PR DESCRIPTION
## 개요
MongoDB chatroom 컬렉션의 식별 키 통일성을 위해 `roomId` 필드를 추가

## 주요 변경사항
- chatroom 문서 내 `roomId` 필드 신규 추가
- 기존 `_id`와의 중복 사용 방지 및 기준 키로 roomId 통일

## 관련 이슈
-  #37 (MongoDB 컬렉션 스키마 통일 관련 논의)