### PR TITLE
[Refactor] MongoDB 컬렉션별 Pydantic 모델 정의 및 적용

### DIFF
--- a/Prompting/common/resonse_util.py
+++ b/Prompting/common/resonse_util.py
@@ -1,13 +1,14 @@
 from fastapi.responses import JSONResponse
+from fastapi.encoders import jsonable_encoder
 from typing import Optional, Any
 
 
 def success_response(data: Optional[Any] = None, message: str = "요청이 성공했습니다."):
     return JSONResponse(
         status_code=200,
-        content={
+        content=jsonable_encoder({
             "status": "SUCCESS",
             "message": message,
             "data": data
-        }
+        })
     )

--- a/Prompting/common/resonse_util.py
+++ b/Prompting/common/resonse_util.py
@@ -1,14 +1,13 @@
 from fastapi.responses import JSONResponse
-from fastapi.encoders import jsonable_encoder
 from typing import Optional, Any
 
 
 def success_response(data: Optional[Any] = None, message: str = "요청이 성공했습니다."):
     return JSONResponse(
         status_code=200,
-        content=jsonable_encoder({
+        content={
             "status": "SUCCESS",
             "message": message,
             "data": data
-        })
+        }
     )

--- a/Prompting/models/__init__.py
+++ b/Prompting/models/__init__.py
@@ -1,3 +1,4 @@
 from .chatroom import RoomModel, AgendaSummaryModel
 from .chat import ChatModel
 from .user import UserModel
+from .agenda import AgendaItemModel

--- a/Prompting/models/__init__.py
+++ b/Prompting/models/__init__.py
@@ -1,0 +1,1 @@
+from .chatroom import RoomModel, AgendaSummaryModel

--- a/Prompting/models/__init__.py
+++ b/Prompting/models/__init__.py
@@ -1,1 +1,2 @@
 from .chatroom import RoomModel, AgendaSummaryModel
+from .chat import ChatModel

--- a/Prompting/models/__init__.py
+++ b/Prompting/models/__init__.py
@@ -1,2 +1,3 @@
 from .chatroom import RoomModel, AgendaSummaryModel
 from .chat import ChatModel
+from .user import UserModel

--- a/Prompting/models/agenda.py
+++ b/Prompting/models/agenda.py
@@ -1,0 +1,7 @@
+from pydantic import BaseModel
+from Prompting.common import AgendaStatus
+
+class AgendaItemModel(BaseModel):
+    title: str
+    status: AgendaStatus
+

--- a/Prompting/models/chat.py
+++ b/Prompting/models/chat.py
@@ -1,0 +1,12 @@
+from pydantic import BaseModel
+
+
+class ChatModel(BaseModel):
+    # _id: str
+    # roomId: str
+    # timestamp: str
+    email: str
+    # name: str
+    message: str
+    agenda_id: str
+

--- a/Prompting/models/chat.py
+++ b/Prompting/models/chat.py
@@ -10,3 +10,6 @@ class ChatModel(BaseModel):
     message: str
     agenda_id: str
 
+    class Config:
+        extra = "ignore"
+

--- a/Prompting/models/chatroom.py
+++ b/Prompting/models/chatroom.py
@@ -18,6 +18,10 @@ class RoomModel(BaseModel):
     # mbti: str
     # summary: list[AgendaSummaryModel]
 
+    @property
+    def full_participants(self) -> list[str]:
+        return list(dict.fromkeys(self.participants + [self.host_email]))  # host까지 포함한 전체 참가자 이메일 리스트
+
     class Config:
         extra = "ignore"
 

--- a/Prompting/models/chatroom.py
+++ b/Prompting/models/chatroom.py
@@ -1,0 +1,20 @@
+from pydantic import BaseModel
+from typing import Optional
+
+
+class AgendaSummaryModel(BaseModel):
+    agendaId: str
+    topic: str
+    content: Optional[str]
+
+
+class RoomModel(BaseModel):
+    # _id: str
+    roomId: str
+    host_email: str
+    # title: str
+    content: str
+    participants: list[str]
+    # mbti: str
+    # summary: list[AgendaSummaryModel]
+

--- a/Prompting/models/chatroom.py
+++ b/Prompting/models/chatroom.py
@@ -18,3 +18,6 @@ class RoomModel(BaseModel):
     # mbti: str
     # summary: list[AgendaSummaryModel]
 
+    class Config:
+        extra = "ignore"
+

--- a/Prompting/models/user.py
+++ b/Prompting/models/user.py
@@ -1,0 +1,8 @@
+from pydantic import BaseModel
+
+
+class UserModel(BaseModel):
+    email: str
+    username: str
+    usermbti: str
+

--- a/Prompting/models/user.py
+++ b/Prompting/models/user.py
@@ -6,3 +6,5 @@ class UserModel(BaseModel):
     username: str
     usermbti: str
 
+    class Config:
+        extra = "ignore"

--- a/Prompting/repository/agenda_repository.py
+++ b/Prompting/repository/agenda_repository.py
@@ -2,6 +2,7 @@ from .mongo_client import db, AGENDA_COLLECTION
 from Prompting.exceptions import MongoAccessError, catch_and_raise
 from Prompting.common import AgendaStatus
 from pymongo import ReturnDocument
+from Prompting.models import AgendaItemModel
 
 
 class AgendaRepository:
@@ -9,7 +10,7 @@ class AgendaRepository:
         self.collection = db[AGENDA_COLLECTION]
 
     @catch_and_raise("MongoDB 안건 저장", MongoAccessError)
-    async def save_agenda(self, room_id: str, agenda_dict: dict) -> dict:
+    async def save_agenda(self, room_id: str, agenda_dict: dict[str, str]) -> dict[str, str]:
         """
         안건 데이터를 MongoDB agenda 콜렉션에 저장
 
@@ -18,7 +19,7 @@ class AgendaRepository:
             agenda_dict: [안건 ID]-[안건명]이 매핑된 dict
 
         Returns:
-            MongoDB에 저장된 안건 문서의 `_id` 필드 (문자열 형태)
+            [안건 ID]-[안건명]이 매핑된 dict (예비 안건을 포함해 실제 저장된 안건 데이터)
         """
         # 마지막 요소로 추가 논의를 위한 예비 안건 추가
         last_agenda_id = str(len(agenda_dict) + 1)
@@ -41,17 +42,23 @@ class AgendaRepository:
         if result.modified_count == 0 and result.upserted_id is None:
             raise MongoAccessError("회의 안건 저장 실패")
 
-        return agenda_dict  # 반환은 안건명만 포함하는 딕셔너리
+        return agenda_dict  # 반환은 [안건 ID]-[안건명]이 매핑된 dict만
 
 
     @catch_and_raise("MongoDB 안건 조회", MongoAccessError)
-    async def get_agenda_by_room(self, room_id: str) -> dict:
+    async def get_agenda_by_room(self, room_id: str) -> dict[str, AgendaItemModel]:
         """채팅방 ID를 기반으로 해당 방의 안건 데이터를 검색"""
-        return await self.collection.find_one({"roomId": room_id})
+        doc = await self.collection.find_one({"roomId": room_id})
+        if doc is None:
+            raise MongoAccessError(f"roomId '{room_id}'에 해당하는 안건 데이터 없음")
+        return {
+            aid: AgendaItemModel(**item)
+            for aid, item in doc.get("agendas", {}).items()
+        }
 
 
     @catch_and_raise("MongoDB 안건 상태 업데이트", MongoAccessError)
-    async def update_status(self, room_id: str, agenda_id: str, is_skipped: bool) -> dict:
+    async def update_status(self, room_id: str, agenda_id: str, is_skipped: bool):
         """
         안건 데이터에서 특정 안건의 논의 상태를 완료 또는 생략 상태로 업데이트
 
@@ -70,4 +77,3 @@ class AgendaRepository:
         if updated_agendas is None:
             raise MongoAccessError("안건 상태 업데이트 실패")
 
-        return updated_agendas["agendas"]

--- a/Prompting/repository/chat_repository.py
+++ b/Prompting/repository/chat_repository.py
@@ -1,19 +1,22 @@
 from .mongo_client import db, CHAT_COLLECTION
 from Prompting.exceptions.errors import MongoAccessError
 from Prompting.exceptions.decorators import catch_and_raise
+from Prompting.models import ChatModel
+
 
 class ChatRepository:
     def __init__(self):
         self.collection = db[CHAT_COLLECTION]
 
     @catch_and_raise("MongoDB 전체 채팅 조회", MongoAccessError)
-    async def get_chat_logs_by_room(self, room_id: str) -> list[dict]:
+    async def get_chat_logs_by_room(self, room_id: str) -> list[ChatModel]:
         """채팅방 ID 기준으로 해당 방의 채팅 기록을 시간 순서대로 조회 (최대 1000개까지)"""
         cursor = self.collection.find({"roomId": room_id}).sort("timestamp", 1)
-        return await cursor.to_list(length=1000)
+        docs = await cursor.to_list(length=1000)
+        return [ChatModel.model_validate(doc) for doc in docs]
 
     @catch_and_raise("MongoDB 지정 안건 채팅 조회", MongoAccessError)
-    async def get_chat_logs_by_agenda_id(self, room_id: str, agenda_id: str) -> list[dict]:
+    async def get_chat_logs_by_agenda_id(self, room_id: str, agenda_id: str) -> list[ChatModel]:
         """
         특정 안건에 대한 채팅 기록을 시간 순으로 조회
 
@@ -31,4 +34,5 @@ class ChatRepository:
             "agenda_id": agenda_id
         }).sort("timestamp", 1)
 
-        return await cursor.to_list(length=1000)
+        docs = await cursor.to_list(length=1000)
+        return [ChatModel.model_validate(doc) for doc in docs]

--- a/Prompting/repository/room_repository.py
+++ b/Prompting/repository/room_repository.py
@@ -9,7 +9,7 @@ class RoomRepository:
     @catch_and_raise("MongoDB 채팅방 정보 조회", MongoAccessError)
     async def get_room_info(self, room_id: str) -> dict:
         """채팅방 ID로 해당 방의 정보를 조회"""
-        doc = await self.collection.find_one({"_id": room_id})
+        doc = await self.collection.find_one({"roomId": room_id})
         return doc
 
     @catch_and_raise("MongoDB 회의 요약 저장", MongoAccessError)
@@ -22,7 +22,7 @@ class RoomRepository:
             summary: 저장할 요약 데이터
         """
         result = await self.collection.update_one(
-            {"_id": room_id},
+            {"roomId": room_id},
             {"$set": {"summary": summary}}
         )
         if result.modified_count == 0:

--- a/Prompting/repository/room_repository.py
+++ b/Prompting/repository/room_repository.py
@@ -1,19 +1,23 @@
 from .mongo_client import db, ROOM_COLLECTION
 from Prompting.exceptions.errors import MongoAccessError
 from Prompting.exceptions.decorators import catch_and_raise
+from Prompting.models import RoomModel, AgendaSummaryModel
+
 
 class RoomRepository:
     def __init__(self):
         self.collection = db[ROOM_COLLECTION]
 
     @catch_and_raise("MongoDB 채팅방 정보 조회", MongoAccessError)
-    async def get_room_info(self, room_id: str) -> dict:
+    async def get_room_info(self, room_id: str) -> RoomModel:
         """채팅방 ID로 해당 방의 정보를 조회"""
         doc = await self.collection.find_one({"roomId": room_id})
-        return doc
+        if doc is None:
+            raise MongoAccessError(f"roomId '{room_id}'에 해당하는 채팅방 없음")
+        return RoomModel(**doc)
 
     @catch_and_raise("MongoDB 회의 요약 저장", MongoAccessError)
-    async def save_summary(self, room_id: str, summary: list[dict]):
+    async def save_summary(self, room_id: str, summary: list[AgendaSummaryModel]):
         """
         room_id를 가진 채팅방 문서에 'summary' 필드 추가 또는 갱신
 
@@ -23,10 +27,7 @@ class RoomRepository:
         """
         result = await self.collection.update_one(
             {"roomId": room_id},
-            {"$set": {"summary": summary}}
+            {"$set": {"summary": [item.dict() for item in summary]}}
         )
-        if result.modified_count == 0:
-            if result.upserted_id is not None:
-                print(f"새로 insert된 문서 ID: {result.upserted_id}")
-            else:
-                raise MongoAccessError("회의 요약 저장 실패")
+        if result.modified_count == 0 and result.upserted_id is None:
+            raise MongoAccessError("회의 요약 저장 실패")

--- a/Prompting/repository/user_repository.py
+++ b/Prompting/repository/user_repository.py
@@ -1,13 +1,15 @@
 from .mongo_client import db, USER_COLLECTION
 from Prompting.exceptions.errors import MongoAccessError
 from Prompting.exceptions.decorators import catch_and_raise
+from Prompting.models import UserModel
+
 
 class UserRepository:
     def __init__(self):
         self.collection = db[USER_COLLECTION]
 
     @catch_and_raise("MongoDB 참여자 정보 목록 조회", MongoAccessError)
-    async def get_user_list_by_emails(self, emails: list[str]) -> list[dict]:
+    async def get_user_list_by_emails(self, emails: list[str]) -> list[UserModel]:
         """
         이메일 목록을 기준으로 사용자 정보를 조회
 
@@ -18,4 +20,5 @@ class UserRepository:
             사용자 정보가 담긴 dict 객체 리스트
         """
         cursor = self.collection.find({"email": {"$in": emails}})
-        return await cursor.to_list(length=None)
+        docs = await cursor.to_list(length=None)
+        return [UserModel.model_validate(doc) for doc in docs]

--- a/Prompting/scripts/insert_test_data.py
+++ b/Prompting/scripts/insert_test_data.py
@@ -19,6 +19,7 @@ def already_inserted():
 def insert_chatroom(title, content, host, participants, mbti=BOT_MBTI):
     chatroom = {
         "_id": TEST_ROOM_ID,
+        "roomId": TEST_ROOM_ID,
         "host_email": host,
         "title": title,
         "content": content,

--- a/Prompting/services/context_builders/meeting_history_builder.py
+++ b/Prompting/services/context_builders/meeting_history_builder.py
@@ -16,7 +16,7 @@ class MeetingHistoryBuilder:
          - 토큰 수 제한에 맞춰 텍스트를 분할
         """
         self.topic: str = context.topic  # 회의 주제
-        self.agendas: dict[str, str] = { aid: context.agendas[aid]["title"] for aid in context.agendas }  # 회의 안건들(번호-주제 쌍)
+        self.agendas: dict[str, str] = {aid: context.agendas[aid].title for aid in context.agendas}  # 회의 안건들(번호-주제 쌍)
         self.host: str = context.host  # 회의 개최자(이메일)
         self.participants: list[UserInfo] = context.participants  # 회의 참여자 리스트
         self.chats: list[ChatLog] = context.chats  # 채팅 기록 리스트

--- a/Prompting/services/meeting_summarizer.py
+++ b/Prompting/services/meeting_summarizer.py
@@ -142,7 +142,7 @@ class MeetingSummarizer:
                 summary_content = key_statements_text + conclusion_text
 
             agenda_summary = {
-                "agendaId": step,
+                "agendaId": str(step),
                 "topic": sub_topic,
                 "content": summary_content
             }

--- a/Prompting/services/meeting_summarizer.py
+++ b/Prompting/services/meeting_summarizer.py
@@ -9,6 +9,7 @@ from Prompting.exceptions.errors import GeminiCallError, GeminiParseError, Mongo
 from .context_builders import MeetingHistoryBuilder
 from typing import cast
 from Prompting.common import AgendaStatus
+from Prompting.models import AgendaSummaryModel
 
 
 class MeetingSummarizer:
@@ -110,7 +111,7 @@ class MeetingSummarizer:
         return cast(list[dict], summary_data)
 
     @catch_and_raise("Gemini 요약 응답 파싱", GeminiParseError)
-    def parse_response_to_summary_data(self, response: list[dict]) -> list[dict]:
+    def parse_response_to_summary_data(self, response: list[dict]) -> list[AgendaSummaryModel]:
         """
         Gemini의 응답을 MongoDB 저장 형식에 맞게 변환
 
@@ -118,8 +119,8 @@ class MeetingSummarizer:
             response: Gemini 응답으로부터 파싱된 회의 요약 list[dict]
 
         Returns:
-            안건별 요약이 담긴 list[dict]
-            안건별 요약 dict는 안건 번호(agendaId), 안건명(topic), 요약 텍스트(content)로 구성
+            안건별 요약이 담긴 list[AgendaSummaryModel]
+            AgendaSummaryModel은 안건 번호(agendaId), 안건명(topic), 요약 텍스트(content)로 구성
         """
         summary_list = []
         for data in response:
@@ -141,12 +142,7 @@ class MeetingSummarizer:
 
                 summary_content = key_statements_text + conclusion_text
 
-            agenda_summary = {
-                "agendaId": str(step),
-                "topic": sub_topic,
-                "content": summary_content
-            }
-
+            agenda_summary = AgendaSummaryModel(agendaId=str(step), topic=sub_topic, content=summary_content)
             summary_list.append(agenda_summary)
 
         return summary_list

--- a/Prompting/services/meeting_summarizer.py
+++ b/Prompting/services/meeting_summarizer.py
@@ -96,7 +96,7 @@ class MeetingSummarizer:
 
         for summary in summary_data:
             aid = str(summary["step"])
-            summary["is_skipped"] = agendas[aid]["status"] == AgendaStatus.SKIPPED
+            summary["is_skipped"] = (agendas[aid].status != AgendaStatus.COMPLETE)
             included_ids.add(aid)
 
         # 누락된 안건 추가
@@ -104,7 +104,7 @@ class MeetingSummarizer:
             if aid not in included_ids:
                 summary_data.append({
                     "step": int(aid),
-                    "sub_topic": agenda["title"],
+                    "sub_topic": agenda.title,
                     "is_skipped": True
                 })
 

--- a/Prompting/usecases/mbti_chat_usecase.py
+++ b/Prompting/usecases/mbti_chat_usecase.py
@@ -44,7 +44,7 @@ async def load_chat_context_and_update_agenda_status(
         # 직전 안건이 생략되지 않고 논의 완료로 처리되었으면, 직전 채팅 내역을 맥락으로 참조.
         if not request.is_previous_skipped:
             chat_data = await chat_repo.get_chat_logs_by_agenda_id(request.roomId, prev_agenda_id)
-            chats = [ChatLog.from_dict(c) for c in chat_data]
+            chats = [ChatLog.from_model(c) for c in chat_data]
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
     room = await load_meeting_room_info(request.roomId, room_repo)

--- a/Prompting/usecases/mbti_chat_usecase.py
+++ b/Prompting/usecases/mbti_chat_usecase.py
@@ -1,7 +1,7 @@
 # MBTI 참여자 챗 생성 하위 use case 모음
 from Prompting.schemas import ChatRequest
 from Prompting.repository import ChatRepository, RoomRepository, UserRepository, AgendaRepository
-from Prompting.usecases.usecase_utils import load_meeting_room_info, load_participants_info
+from Prompting.usecases.usecase_utils import load_participants_info
 from Prompting.usecases.meeting_context import MeetingContext, ChatLog
 from Prompting.exceptions import catch_and_raise, MongoAccessError
 from fastapi.exceptions import RequestValidationError
@@ -47,13 +47,13 @@ async def load_chat_context_and_update_agenda_status(
             chats = [ChatLog.from_model(c) for c in chat_data]
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
-    room = await load_meeting_room_info(request.roomId, room_repo)
-    participants = await load_participants_info(room.participants, user_repo)
+    room_model = await room_repo.get_room_info(request.roomId)
+    participants = await load_participants_info(room_model.full_participants, user_repo)
 
     return MeetingContext(
-        topic=room.content,
+        topic=room_model.content,
         agendas=agendas,
-        host=room.host,
+        host=room_model.host_email,
         participants=participants,
         chats=chats
     )

--- a/Prompting/usecases/mbti_chat_usecase.py
+++ b/Prompting/usecases/mbti_chat_usecase.py
@@ -31,15 +31,15 @@ async def load_chat_context_and_update_agenda_status(
     """
 
     # 해당 회의의 안건 데이터 읽어와 요청에 포함된 안건 ID가 유효한지 검사
-    agenda_data = await agenda_repo.get_agenda_by_room(request.roomId)
-    if request.agendaId not in agenda_data.get('agendas').keys():
+    agendas = await agenda_repo.get_agenda_by_room(request.roomId)
+    if request.agendaId not in agendas.keys():
         raise RequestValidationError([{"loc": ["agendaId"], "msg": "유효하지 않은 안건 번호", "type": "value_error"}])
 
     chats = []
     if request.agendaId != '1':  # 첫 번째 안건이 아닌 경우에만
         # 직전 안건의 상태 업데이트
         prev_agenda_id = str(int(request.agendaId) - 1)
-        agendas = await agenda_repo.update_status(request.roomId, prev_agenda_id, request.is_previous_skipped)
+        await agenda_repo.update_status(request.roomId, prev_agenda_id, request.is_previous_skipped)
 
         # 직전 안건이 생략되지 않고 논의 완료로 처리되었으면, 직전 채팅 내역을 맥락으로 참조.
         if not request.is_previous_skipped:
@@ -52,7 +52,7 @@ async def load_chat_context_and_update_agenda_status(
 
     return MeetingContext(
         topic=room.content,
-        agendas=agenda_data["agendas"],
+        agendas=agendas,
         host=room.host,
         participants=participants,
         chats=chats

--- a/Prompting/usecases/meeting_context.py
+++ b/Prompting/usecases/meeting_context.py
@@ -1,6 +1,6 @@
 # use case에서 쓰이는 data class 정의 모음
 from dataclasses import dataclass
-from Prompting.models import RoomModel
+from Prompting.models import RoomModel, ChatModel
 
 @dataclass
 class RoomInfo:
@@ -37,11 +37,11 @@ class ChatLog:
     agenda_id: str
 
     @classmethod
-    def from_dict(cls, data: dict) -> "ChatLog":
+    def from_model(cls, model: ChatModel) -> "ChatLog":
         return cls(
-            sender=data.get("email", ""),
-            message=data.get("message", ""),
-            agenda_id=data.get("agenda_id", "")
+            sender=model.email,
+            message=model.message,
+            agenda_id=model.agenda_id,
         )
 
 @dataclass

--- a/Prompting/usecases/meeting_context.py
+++ b/Prompting/usecases/meeting_context.py
@@ -1,5 +1,6 @@
 # use case에서 쓰이는 data class 정의 모음
 from dataclasses import dataclass
+from Prompting.models import RoomModel
 
 @dataclass
 class RoomInfo:
@@ -8,11 +9,11 @@ class RoomInfo:
     participants: list[str]  # host 포함
 
     @classmethod
-    def from_dict(cls, data: dict) -> "RoomInfo":
+    def from_model(cls, model: RoomModel) -> "RoomInfo":
         return cls(
-            content=data.get("content", ""),
-            host=data.get("host", ""),
-            participants=data.get("participants", []) + [data.get("host", "")]
+            content=model.content,
+            host=model.host_email,
+            participants=model.participants + [model.host_email]
         )
 
 @dataclass

--- a/Prompting/usecases/meeting_context.py
+++ b/Prompting/usecases/meeting_context.py
@@ -1,20 +1,7 @@
 # use case에서 쓰이는 data class 정의 모음
 from dataclasses import dataclass
-from Prompting.models import RoomModel, ChatModel, UserModel, AgendaItemModel
+from Prompting.models import ChatModel, UserModel, AgendaItemModel
 
-@dataclass
-class RoomInfo:
-    content: str
-    host: str
-    participants: list[str]  # host 포함
-
-    @classmethod
-    def from_model(cls, model: RoomModel) -> "RoomInfo":
-        return cls(
-            content=model.content,
-            host=model.host_email,
-            participants=model.participants + [model.host_email]
-        )
 
 @dataclass
 class UserInfo:

--- a/Prompting/usecases/meeting_context.py
+++ b/Prompting/usecases/meeting_context.py
@@ -1,6 +1,6 @@
 # use case에서 쓰이는 data class 정의 모음
 from dataclasses import dataclass
-from Prompting.models import RoomModel, ChatModel
+from Prompting.models import RoomModel, ChatModel, UserModel
 
 @dataclass
 class RoomInfo:
@@ -23,11 +23,11 @@ class UserInfo:
     mbti: str
 
     @classmethod
-    def from_dict(cls, data: dict) -> "UserInfo":
+    def from_model(cls, model: UserModel) -> "UserInfo":
         return cls(
-            email=data.get("email", ""),
-            name=data.get("username", ""),
-            mbti=data.get("usermbti", "")
+            email=model.email,
+            name=model.username,
+            mbti=model.usermbti
         )
 
 @dataclass

--- a/Prompting/usecases/meeting_context.py
+++ b/Prompting/usecases/meeting_context.py
@@ -1,6 +1,6 @@
 # use case에서 쓰이는 data class 정의 모음
 from dataclasses import dataclass
-from Prompting.models import RoomModel, ChatModel, UserModel
+from Prompting.models import RoomModel, ChatModel, UserModel, AgendaItemModel
 
 @dataclass
 class RoomInfo:
@@ -47,7 +47,7 @@ class ChatLog:
 @dataclass
 class MeetingContext:
     topic: str
-    agendas: dict
+    agendas: dict[str, AgendaItemModel]  # agenda_id -> AgendaItemModel
     host: str
     participants: list[UserInfo]
     chats: list[ChatLog]

--- a/Prompting/usecases/summarize_usecase.py
+++ b/Prompting/usecases/summarize_usecase.py
@@ -29,13 +29,13 @@ async def load_summary_context_and_update_agenda_status(
     """
 
     # 해당 회의의 안건 데이터와 전체 채팅 내역 읽어오기
-    agenda_data = await agenda_repo.get_agenda_by_room(request.roomId)
+    agendas = await agenda_repo.get_agenda_by_room(request.roomId)
     chat_data = await chat_repo.get_chat_logs_by_room(request.roomId)
     chats = [ChatLog.from_model(c) for c in chat_data]
 
     # 마지막 안건의 상태 업데이트
-    last_agenda_id = str(len(agenda_data["agendas"]))
-    agendas = await agenda_repo.update_status(request.roomId, last_agenda_id, request.is_last_agenda_skipped)
+    last_agenda_id = str(len(agendas))
+    await agenda_repo.update_status(request.roomId, last_agenda_id, request.is_last_agenda_skipped)
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
     room = await load_meeting_room_info(request.roomId, room_repo)

--- a/Prompting/usecases/summarize_usecase.py
+++ b/Prompting/usecases/summarize_usecase.py
@@ -31,7 +31,7 @@ async def load_summary_context_and_update_agenda_status(
     # 해당 회의의 안건 데이터와 전체 채팅 내역 읽어오기
     agenda_data = await agenda_repo.get_agenda_by_room(request.roomId)
     chat_data = await chat_repo.get_chat_logs_by_room(request.roomId)
-    chats = [ChatLog.from_dict(c) for c in chat_data]
+    chats = [ChatLog.from_model(c) for c in chat_data]
 
     # 마지막 안건의 상태 업데이트
     last_agenda_id = str(len(agenda_data["agendas"]))

--- a/Prompting/usecases/summarize_usecase.py
+++ b/Prompting/usecases/summarize_usecase.py
@@ -1,6 +1,6 @@
 # 요약 생성 요청 시 활용되는 하위 Use Case 모음
 from Prompting.repository import ChatRepository, RoomRepository, UserRepository, AgendaRepository
-from Prompting.usecases.usecase_utils import load_meeting_room_info, load_participants_info
+from Prompting.usecases.usecase_utils import load_participants_info
 from Prompting.usecases.meeting_context import MeetingContext, ChatLog
 from Prompting.exceptions import catch_and_raise, MongoAccessError
 from Prompting.schemas import SummaryRequest
@@ -38,13 +38,13 @@ async def load_summary_context_and_update_agenda_status(
     await agenda_repo.update_status(request.roomId, last_agenda_id, request.is_last_agenda_skipped)
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
-    room = await load_meeting_room_info(request.roomId, room_repo)
-    participants = await load_participants_info(room.participants, user_repo)
+    room_model = await room_repo.get_room_info(request.roomId)
+    participants = await load_participants_info(room_model.full_participants, user_repo)
 
     return MeetingContext(
-        topic=room.content,
+        topic=room_model.content,
         agendas=agendas,
-        host=room.host,
+        host=room_model.host_email,
         participants=participants,
         chats=chats
     )

--- a/Prompting/usecases/usecase_utils.py
+++ b/Prompting/usecases/usecase_utils.py
@@ -1,21 +1,6 @@
 # 여러 use case에서 활용되는 공통 유틸 함수
-from Prompting.repository import RoomRepository, UserRepository
-from Prompting.usecases.meeting_context import RoomInfo, UserInfo
-
-
-async def load_meeting_room_info(room_id: str, room_repo: RoomRepository) -> RoomInfo:
-    """
-    MongoDB에서 회의 채팅방 정보 가져오기
-
-    Args:
-        room_id: 채팅방 ID
-        room_repo: 채팅방 데이터 관리 객체
-
-    Returns:
-        채팅방 정보(주최자, 참여자, 회의 주제 설명 포함)
-    """
-    room_model = await room_repo.get_room_info(room_id)
-    return RoomInfo.from_model(room_model)
+from Prompting.repository import UserRepository
+from Prompting.usecases.meeting_context import UserInfo
 
 
 async def load_participants_info(email_list: list[str], user_repo: UserRepository) -> list[UserInfo]:

--- a/Prompting/usecases/usecase_utils.py
+++ b/Prompting/usecases/usecase_utils.py
@@ -29,5 +29,5 @@ async def load_participants_info(email_list: list[str], user_repo: UserRepositor
     Returns:
         회의 참여자의 세부 정보 목록(이름, 이메일, mbti 포함)
     """
-    user_info_dicts = await user_repo.get_user_list_by_emails(email_list)
-    return [UserInfo.from_dict(info) for info in user_info_dicts]
+    user_data = await user_repo.get_user_list_by_emails(email_list)
+    return [UserInfo.from_model(u) for u in user_data]

--- a/Prompting/usecases/usecase_utils.py
+++ b/Prompting/usecases/usecase_utils.py
@@ -14,8 +14,8 @@ async def load_meeting_room_info(room_id: str, room_repo: RoomRepository) -> Roo
     Returns:
         채팅방 정보(주최자, 참여자, 회의 주제 설명 포함)
     """
-    room_data = await room_repo.get_room_info(room_id)
-    return RoomInfo.from_dict(room_data)
+    room_model = await room_repo.get_room_info(room_id)
+    return RoomInfo.from_model(room_model)
 
 
 async def load_participants_info(email_list: list[str], user_repo: UserRepository) -> list[UserInfo]:


### PR DESCRIPTION
## 개요
MongoDB 연동 일관성 및 타입 안전성 확보를 위해 주요 컬렉션에 대한 Pydantic 모델을 정의하고 레포지토리에서 적용

## 주요 변경사항
- `Prompting.models` 모듈에 다음 컬렉션용 Pydantic 모델 정의:
  - `AgendaItemModel`
  - `ChatModel`
  - `RoomModel`
  - `AgendaSummaryModel` 
  - `UserModel`
- 각 레포지토리에서 dict → model 변환 방식 적용
- 일부 필드에 대해 `extra = "ignore"` 처리 추가 (불필요 필드 무시)
- RoomInfo -> RoomModel로 대체 : 로직 내 임시로만 사용되던 도메인 모델 제거, 구조 단순화

## 관련 이슈
-  #37 