### PR TITLE
[Refactor] chatroom 컬렉션 host_email -> host 필드명 변경

### DIFF
--- a/Prompting/models/chatroom.py
+++ b/Prompting/models/chatroom.py
@@ -11,16 +11,12 @@ class AgendaSummaryModel(BaseModel):
 class RoomModel(BaseModel):
     # _id: str
     roomId: str
-    host_email: str
+    host: str
     # title: str
     content: str
     participants: list[str]
     # mbti: str
     # summary: list[AgendaSummaryModel]
-
-    @property
-    def full_participants(self) -> list[str]:
-        return list(dict.fromkeys(self.participants + [self.host_email]))  # host까지 포함한 전체 참가자 이메일 리스트
 
     class Config:
         extra = "ignore"

--- a/Prompting/scripts/insert_test_data.py
+++ b/Prompting/scripts/insert_test_data.py
@@ -20,7 +20,7 @@ def insert_chatroom(title, content, host, participants, mbti=BOT_MBTI):
     chatroom = {
         "_id": TEST_ROOM_ID,
         "roomId": TEST_ROOM_ID,
-        "host_email": host,
+        "host": host,
         "title": title,
         "content": content,
         "participants": participants,

--- a/Prompting/usecases/mbti_chat_usecase.py
+++ b/Prompting/usecases/mbti_chat_usecase.py
@@ -48,12 +48,12 @@ async def load_chat_context_and_update_agenda_status(
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
     room_model = await room_repo.get_room_info(request.roomId)
-    participants = await load_participants_info(room_model.full_participants, user_repo)
+    participants = await load_participants_info(room_model.participants, user_repo)
 
     return MeetingContext(
         topic=room_model.content,
         agendas=agendas,
-        host=room_model.host_email,
+        host=room_model.host,
         participants=participants,
         chats=chats
     )

--- a/Prompting/usecases/summarize_usecase.py
+++ b/Prompting/usecases/summarize_usecase.py
@@ -39,12 +39,12 @@ async def load_summary_context_and_update_agenda_status(
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
     room_model = await room_repo.get_room_info(request.roomId)
-    participants = await load_participants_info(room_model.full_participants, user_repo)
+    participants = await load_participants_info(room_model.participants, user_repo)
 
     return MeetingContext(
         topic=room_model.content,
         agendas=agendas,
-        host=room_model.host_email,
+        host=room_model.host,
         participants=participants,
         chats=chats
     )


### PR DESCRIPTION
## 개요
MongoDB `chatroom` 컬렉션의 회의 주최자를 의미하는 필드명을 `host_email` -> `host`로 변경하여 통일

## 주요 변경 사항
- `chatroom` 레포지토리 모델인 RoomModel 정의 수정 및 usecase에 반영
   - `chatroom`의 `participants` 필드를 `host`까지 포함하는 것으로 확정했기에 `full_participants` 프로퍼티 구현도 제거
- 테스트 데이터 삽입용 스크립트도 주최자 필드명을 `host`로 하여 데이터를 추가하도록 수정

## 관련 이슈
-  #37 