### PR TITLE
[Refactor] 채팅방 메시지 저장 구조 변경: 모든 메세지 개별 저장 -> 안건별 메세지 매핑

### DIFF
--- a/Prompting/models/__init__.py
+++ b/Prompting/models/__init__.py
@@ -1,4 +1,4 @@
 from .chatroom import RoomModel, AgendaSummaryModel
-from .chat import ChatModel
+from .chat import ChatMessage, RoomMessages
 from .user import UserModel
 from .agenda import AgendaItemModel

--- a/Prompting/models/chat.py
+++ b/Prompting/models/chat.py
@@ -1,14 +1,30 @@
 from pydantic import BaseModel
+from datetime import datetime
 
 
-class ChatModel(BaseModel):
-    # _id: str
-    # roomId: str
-    # timestamp: str
+class ChatMessage(BaseModel):
+    """
+    ChatMessage: 개별 채팅 메세지 데이터 구조.
+    """
+    name: str
     email: str
-    # name: str
     message: str
-    agenda_id: str
+    agendaId: str
+    timestamp: datetime
+
+    class Config:
+        extra = "ignore"
+
+
+class RoomMessages(BaseModel):
+    """
+    RoomMessages: 특정 채팅방의 메시지를 안건 ID별로 나눈 데이터 구조.
+
+    - _id: 채팅방 ID(uuid 형식)
+    - messages: {agenda_id: [ChatMessage, ...], }
+    """
+    _id: str
+    messages: dict[str, list[ChatMessage]]   # 안건 ID(aid) - 안건에 대한 채팅 내역
 
     class Config:
         extra = "ignore"

--- a/Prompting/repository/chat_repository.py
+++ b/Prompting/repository/chat_repository.py
@@ -1,7 +1,8 @@
 from .mongo_client import db, CHAT_COLLECTION
 from Prompting.exceptions.errors import MongoAccessError
 from Prompting.exceptions.decorators import catch_and_raise
-from Prompting.models import ChatModel
+from Prompting.models import ChatMessage, RoomMessages
+from collections import OrderedDict
 
 
 class ChatRepository:
@@ -9,30 +10,32 @@ class ChatRepository:
         self.collection = db[CHAT_COLLECTION]
 
     @catch_and_raise("MongoDB 전체 채팅 조회", MongoAccessError)
-    async def get_chat_logs_by_room(self, room_id: str) -> list[ChatModel]:
-        """채팅방 ID 기준으로 해당 방의 채팅 기록을 시간 순서대로 조회 (최대 1000개까지)"""
-        cursor = self.collection.find({"roomId": room_id}).sort("timestamp", 1)
-        docs = await cursor.to_list(length=1000)
-        return [ChatModel.model_validate(doc) for doc in docs]
+    async def get_chat_logs_by_room(self, room_id: str) -> OrderedDict[str, list[ChatMessage]]:
+        """채팅방 ID 기준으로 해당 방의 전체 채팅 기록을 시간 순서대로 조회. 안건 ID-채팅내역 맵을 반환."""
+
+        doc = await self.collection.find_one({"_id": room_id})
+        if doc is None:
+            raise MongoAccessError(f"roomId '{room_id}'에 해당하는 채팅 데이터 없음")
+
+        room_msgs = RoomMessages(**doc)
+        agenda_chat_map = room_msgs.messages
+
+        # 각 agenda의 채팅 리스트를 timestamp 기준 정렬
+        for aid in agenda_chat_map:
+            agenda_chat_map[aid].sort(key=lambda chat: chat.timestamp)
+
+        sorted_agenda_chat_map = sorted(agenda_chat_map.items(), key=lambda item: int(item[0]))  # agenda_id 정렬
+        return OrderedDict(sorted_agenda_chat_map)
+
 
     @catch_and_raise("MongoDB 지정 안건 채팅 조회", MongoAccessError)
-    async def get_chat_logs_by_agenda_id(self, room_id: str, agenda_id: str) -> list[ChatModel]:
-        """
-        특정 안건에 대한 채팅 기록을 시간 순으로 조회
+    async def get_chat_logs_by_agenda_id(self, room_id: str, agenda_id: str) -> dict[str, list[ChatMessage]]:
+        """특정 안건에 대한 채팅 기록을 시간 순으로 조회"""
 
-        Args:
-            room_id: 채팅방 ID
-            agenda_id: 채팅을 조회하려는 안건 ID
+        doc = await self.collection.find_one({"_id": room_id})
+        if doc is None:
+            raise MongoAccessError(f"roomId '{room_id}'에 해당하는 채팅 데이터 없음")
 
-        Returns:
-            특정 안건에 대한 채팅 기록 리스트
-        """
+        room_msgs = RoomMessages(**doc)
+        return {agenda_id: sorted(room_msgs.messages[agenda_id], key=lambda chat: chat.timestamp)}
 
-        # 해당 채팅방에서 agenda_id 안건에 대한 모든 chat을 시간 순으로 정렬해 불러오기
-        cursor = self.collection.find({
-            "roomId": room_id,
-            "agenda_id": agenda_id
-        }).sort("timestamp", 1)
-
-        docs = await cursor.to_list(length=1000)
-        return [ChatModel.model_validate(doc) for doc in docs]

--- a/Prompting/scripts/insert_test_data.py
+++ b/Prompting/scripts/insert_test_data.py
@@ -16,41 +16,36 @@ db = client[MONGO_DB_NAME]
 def already_inserted():
     return db[ROOM_COLLECTION].find_one({"_id": TEST_ROOM_ID}) is not None
 
-def insert_chatroom(title, content, host, participants, mbti=BOT_MBTI):
+def insert_chatroom(title, content, host, participants):
     chatroom = {
         "_id": TEST_ROOM_ID,
         "roomId": TEST_ROOM_ID,
-        "host": host,
         "title": title,
-        "content": content,
+        "host": host,
         "participants": participants,
-        "mbti": mbti,
+        "content": content,
         "meta": {"version": "v1"}   # 테스트용 데이터 구분을 위한 메타 정보
     }
     db[ROOM_COLLECTION].insert_one(chatroom)
     return TEST_ROOM_ID      # 문서 id 반환
 
-def insert_chat(timestamp, roomId, sender_email, sender_name, msg, agendaId):
-    chat = {
-        "roomId": roomId,
-        "timestamp": timestamp,
-        "email": sender_email,
-        "name": sender_name,
-        "message": msg,
-        "agenda_id": agendaId,
+def insert_room_messages(roomId, messages):
+    room_messages = {
+        "_id": roomId,
+        "messages": messages,
         "meta": {"version": "v1"}
     }
-    db[CHAT_COLLECTION].insert_one(chat)
+    db[CHAT_COLLECTION].insert_one(room_messages)
 
 def insert_user(email, name, mbti="ISTJ", password="1234qwer!"):
-    chat = {
+    user = {
         "email": email,
-        "password": password,
         "username": name,
         "usermbti": mbti,
+        "password": password,
         "meta": {"version": "v1"}
     }
-    db[USER_COLLECTION].insert_one(chat)
+    db[USER_COLLECTION].insert_one(user)
 
 def insert_agenda(roomId, agendas_dict):
     last_agenda_id = str(len(agendas_dict) + 1)
@@ -111,11 +106,13 @@ def insert_sample_meeting_data(json_file_path, ai_mbti):
 
     contents = data.get('contents', [])  # 안건별 발언 내용
     agendas = {}
+    messages = {}
     chat_idx = 0
     for content in contents:
         step = content.get('step', '0')  # 안건 번호
         sub_topic = content.get('sub_topic', '')  # 안건 제목
         agendas[step] = sub_topic
+        messages[step] = []
 
         chat_list = content.get('utterance', [])  # 발언 목록
         for c in chat_list:
@@ -125,20 +122,24 @@ def insert_sample_meeting_data(json_file_path, ai_mbti):
 
             # 임의 타임 스탬프 찍기(5초 간격)
             now = datetime.now()
-            delayed_time = now + timedelta(seconds=5*chat_idx)
-            timestamp =delayed_time.strftime("%Y-%m-%d %H:%M:%S")
+            timestamp = now + timedelta(seconds=5*chat_idx)
 
             # msgId = f"{roomId}-{str(chat_idx).zfill(10)}",  # 일단 임의로 부여
-            insert_chat(
-                timestamp=timestamp,
-                roomId=roomId,
-                sender_email=email,
-                sender_name=name,
-                msg=msg,
-                agendaId=step
-            )
+            chat = {
+                "name": name,
+                "email": email,
+                "message": msg,
+                "agendaId": step,
+                "timestamp": timestamp
+            }
+            messages[step].append(chat)
             chat_idx += 1
+
     insert_agenda(roomId=roomId, agendas_dict=agendas)
+    insert_room_messages(
+        roomId=roomId,
+        messages=messages
+    )
 
 
 if not already_inserted():

--- a/Prompting/usecases/mbti_chat_usecase.py
+++ b/Prompting/usecases/mbti_chat_usecase.py
@@ -35,7 +35,7 @@ async def load_chat_context_and_update_agenda_status(
     if request.agendaId not in agendas.keys():
         raise RequestValidationError([{"loc": ["agendaId"], "msg": "유효하지 않은 안건 번호", "type": "value_error"}])
 
-    chats = []
+    chats = {}
     if request.agendaId != '1':  # 첫 번째 안건이 아닌 경우에만
         # 직전 안건의 상태 업데이트
         prev_agenda_id = str(int(request.agendaId) - 1)
@@ -43,8 +43,8 @@ async def load_chat_context_and_update_agenda_status(
 
         # 직전 안건이 생략되지 않고 논의 완료로 처리되었으면, 직전 채팅 내역을 맥락으로 참조.
         if not request.is_previous_skipped:
-            chat_data = await chat_repo.get_chat_logs_by_agenda_id(request.roomId, prev_agenda_id)
-            chats = [ChatLog.from_model(c) for c in chat_data]
+            agenda_chat_map = await chat_repo.get_chat_logs_by_agenda_id(request.roomId, prev_agenda_id)
+            chats = {aid: [ChatLog.from_model(c) for c in msgs] for aid, msgs in agenda_chat_map.items()}
 
     # 회의 참여자 정보(이메일, 이름, mbti) 불러오기
     room_model = await room_repo.get_room_info(request.roomId)

--- a/Prompting/usecases/meeting_context.py
+++ b/Prompting/usecases/meeting_context.py
@@ -1,6 +1,6 @@
 # use case에서 쓰이는 data class 정의 모음
 from dataclasses import dataclass
-from Prompting.models import ChatModel, UserModel, AgendaItemModel
+from Prompting.models import ChatMessage, UserModel, AgendaItemModel
 
 
 @dataclass
@@ -24,11 +24,11 @@ class ChatLog:
     agenda_id: str
 
     @classmethod
-    def from_model(cls, model: ChatModel) -> "ChatLog":
+    def from_model(cls, model: ChatMessage) -> "ChatLog":
         return cls(
             sender=model.email,
             message=model.message,
-            agenda_id=model.agenda_id,
+            agenda_id=model.agendaId,
         )
 
 @dataclass
@@ -37,4 +37,4 @@ class MeetingContext:
     agendas: dict[str, AgendaItemModel]  # agenda_id -> AgendaItemModel
     host: str
     participants: list[UserInfo]
-    chats: list[ChatLog]
+    chats: dict[str, list[ChatLog]]  # agenda_id -> 안건별 채팅 내역

--- a/Prompting/usecases/summarize_usecase.py
+++ b/Prompting/usecases/summarize_usecase.py
@@ -30,8 +30,8 @@ async def load_summary_context_and_update_agenda_status(
 
     # 해당 회의의 안건 데이터와 전체 채팅 내역 읽어오기
     agendas = await agenda_repo.get_agenda_by_room(request.roomId)
-    chat_data = await chat_repo.get_chat_logs_by_room(request.roomId)
-    chats = [ChatLog.from_model(c) for c in chat_data]
+    agenda_chat_map = await chat_repo.get_chat_logs_by_room(request.roomId)
+    chats = {aid: [ChatLog.from_model(c) for c in msgs] for aid, msgs in agenda_chat_map.items()}
 
     # 마지막 안건의 상태 업데이트
     last_agenda_id = str(len(agendas))


### PR DESCRIPTION
## 개요
`chat` 컬렉션 데이터를 Spring 백엔드에서 사용하는 구조와 맞춰, `messages` 필드에 안건별 메세지들을 안건 ID-채팅 리스트 쌍의 Object로 저장하는 구조로 변경

## 주요 변경사항
- **`chat` 관련 MongoDB 데이터 모델 구조 개편**
  - 기존에는 `ChatModel` 단일 모델을 사용해 개별 메시지를 직접 다룸
  - 변경 후에는 `ChatMessage`(단일 메시지)와 `RoomMessages`(특정 채팅방의 안건별 메시지 맵)로 역할 분리하여 구조화
 
- **`ChatRepository` 내부 로직 수정**
  - MongoDB에서 데이터를 조회할 때, 안건 ID 기준으로 메시지를 그룹화하여 반환
  - 각 안건의 메시지 리스트는 `timestamp` 기준으로 정렬
  - 반환 형식이 `{ agenda_id: [ChatMessage, ...] }` 형태로 변경됨
  
- **`MeetingContext` 및 `MeetingHistoryBuilder` 구조 수정**
  - `MeetingContext`는 이제 전체 채팅 리스트 대신 안건별 메시지 맵을 참조
  - `MeetingHistoryBuilder`는 agenda ID를 기준으로 채팅을 순회하며 context 문자열을 구성하도록 로직 수정

## 관련 이슈
#37 